### PR TITLE
Fix daily repeat of last trigger

### DIFF
--- a/custom_components/dlink_hnap/binary_sensor.py
+++ b/custom_components/dlink_hnap/binary_sensor.py
@@ -118,7 +118,7 @@ class DlinkMotionSensor(DlinkBinarySensor):
         if not last_trigger:
             return
 
-        has_timed_out = (datetime.now() - last_trigger).seconds > self._timeout
+        has_timed_out = datetime.now() > last_trigger + timedelta(seconds=self._timeout)
         if has_timed_out:
             if self._on:
                 self._on = False


### PR DESCRIPTION
The current check in the binary sensor uses the date time attribute of 'seconds'. However, this shows the number of seconds within a day since the event occurred and does not account for it being more than 24 hours. The proposed change adds the timeout to the last trigger and compares that to 'now' so that any time lapse however long will be accounted for.