### PR TITLE
Add iot_class as required by hassfest

### DIFF
--- a/custom_components/dlink_hnap/manifest.json
+++ b/custom_components/dlink_hnap/manifest.json
@@ -7,5 +7,6 @@
         "@postlund"
     ],
     "issue_tracker": "https://github.com/postlund/dlink_hnap/issues",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "iot_class": "local_polling"
 }


### PR DESCRIPTION
hassfest is failing because manifest.json has no iot_class. Adding it as local_polling.